### PR TITLE
feat: ingest core building datasets & add Building repository 

### DIFF
--- a/backend/common/models/acris.py
+++ b/backend/common/models/acris.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+from dataclasses import dataclass, field
+from typing import Optional, List, Dict
+from datetime import datetime
+from decimal import Decimal
+
+@dataclass
+class AcrisMaster:
+    document_id: str
+    borough: Optional[int]
+    doc_type: Optional[str]
+    doc_date: Optional[datetime]
+    doc_amount: Optional[Decimal]
+
+@dataclass
+class AcrisLegal:
+    document_id: str
+    bbl: Optional[str]
+    borough: Optional[int]
+    block: Optional[int]
+    lot: Optional[int]
+
+@dataclass
+class AcrisParty:
+    document_id: str
+    party_type: Optional[str]
+    name: Optional[str]
+    address1: Optional[str]
+    city: Optional[str]
+    state: Optional[str]
+    zip: Optional[str]
+

--- a/backend/common/models/affordable_housing_record.py
+++ b/backend/common/models/affordable_housing_record.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+from dataclasses import dataclass, field
+from typing import Optional, List, Dict
+from datetime import datetime
+from decimal import Decimal
+
+
+@dataclass
+class AffordableHousingRecord:
+    project_id: int
+    bbl: Optional[str]
+    project_name: Optional[str]
+    project_start_date: Optional[datetime]
+    reporting_construction_type: Optional[str]
+    extended_affordability_status: Optional[str]
+    prevailing_wage_status: Optional[str]
+    extremely_low_income_units: Optional[int]
+    very_low_income_units: Optional[int]
+    low_income_units: Optional[int]
+    counted_rental_units: Optional[int]
+    all_counted_units: Optional[int]
+    total_units: Optional[int]

--- a/backend/common/models/building.py
+++ b/backend/common/models/building.py
@@ -1,6 +1,149 @@
-import dataclasses
+from __future__ import annotations
+from dataclasses import dataclass, field
+from typing import Optional, List, Dict
+from decimal import Decimal
+
+from common.models.acris import AcrisLegal, AcrisParty, AcrisMaster
+from common.models.affordable_housing_record import AffordableHousingRecord
+from common.models.complaint import Complaint
+from common.models.eviction import Eviction
+from common.models.registration import Registration
+from common.models.registration_contact import RegistrationContact
+from common.models.rent_stabilized_tag import RentStabilizedTag
+from common.models.violation import Violation
 
 
-@dataclasses
+@dataclass
 class Building:
-    pass
+    bbl: str
+    registration: Optional[Registration] = None
+    rent_stabilized: Optional[RentStabilizedTag] = None
+    contacts: List[RegistrationContact] = field(default_factory=list)
+    affordable: List[AffordableHousingRecord] = field(default_factory=list)
+    complaints: List[Complaint] = field(default_factory=list)
+    violations: List[Violation] = field(default_factory=list)
+    acris_master: Dict[str, AcrisMaster] = field(default_factory=dict)
+    acris_legals: Dict[str, List[AcrisLegal]] = field(default_factory=dict)
+    acris_parties: Dict[str, List[AcrisParty]] = field(default_factory=dict)
+    evictions: List[Eviction] = field(default_factory=list)
+
+    def set_registration(self, r: Registration):
+        if r and r.bbl == self.bbl:
+            self.registration = r
+
+    def set_rent_stabilized(self, tag: RentStabilizedTag):
+        if tag and tag.bbl == self.bbl:
+            self.rent_stabilized = tag
+
+    def add_contact(self, c: RegistrationContact):
+        self.contacts.append(c)
+
+    def add_affordable(self, a: AffordableHousingRecord):
+        if a and all(x.project_id != a.project_id for x in self.affordable):
+            self.affordable.append(a)
+
+    def add_complaint(self, c: Complaint):
+        if c and all(x.complaint_id != c.complaint_id for x in self.complaints):
+            self.complaints.append(c)
+
+    def add_violation(self, v: Violation):
+        if v and all(x.violation_id != v.violation_id for x in self.violations):
+            if v.class_ is None and hasattr(v, "class"):
+                v.class_ = getattr(v, "class")
+            self.violations.append(v)
+
+    def add_eviction(self, e: Eviction):
+        if not e:
+            return
+        key = (e.docket_number or "", e.court_index_number or "")
+        exists = any((x.docket_number or "", x.court_index_number or "") == key for x in self.evictions)
+        if not exists:
+            self.evictions.append(e)
+
+    def upsert_acris_master(self, m: AcrisMaster):
+        if m and m.document_id:
+            self.acris_master[m.document_id] = m
+
+    def add_acris_legal(self, l: AcrisLegal):
+        if l and l.document_id:
+            self.acris_legals.setdefault(l.document_id, []).append(l)
+
+    def add_acris_party(self, p: AcrisParty):
+        if p and p.document_id:
+            self.acris_parties.setdefault(p.document_id, []).append(p)
+
+def as_registration(row: dict) -> Registration:
+    return Registration(**row)
+
+def as_registration_contact(row: dict) -> RegistrationContact:
+    return RegistrationContact(**row)
+
+def as_affordable(row: dict) -> AffordableHousingRecord:
+    return AffordableHousingRecord(**row)
+
+def as_complaint(row: dict) -> Complaint:
+    return Complaint(**row)
+
+def as_violation(row: dict) -> Violation:
+    if "class" in row and "class_" not in row:
+        row = {**row, "class_": row["class"]}
+        row.pop("class")
+    return Violation(**row)
+
+def as_eviction(row: dict) -> Eviction:
+    return Eviction(**row)
+
+def as_acris_master(row: dict) -> AcrisMaster:
+    amt = row.get("doc_amount")
+    if isinstance(amt, str):
+        try:
+            row = {**row, "doc_amount": Decimal(amt)}
+        except Exception:
+            row = {**row, "doc_amount": None}
+    return AcrisMaster(**row)
+
+def as_acris_legal(row: dict) -> AcrisLegal:
+    return AcrisLegal(**row)
+
+def as_acris_party(row: dict) -> AcrisParty:
+    return AcrisParty(**row)
+
+def as_rent_tag(row: dict) -> RentStabilizedTag:
+    return RentStabilizedTag(**row)
+
+def build_building_from_rows(
+    bbl: str,
+    reg_row: Optional[dict],
+    contact_rows: List[dict],
+    affordable_rows: List[dict],
+    complaint_rows: List[dict],
+    violation_rows: List[dict],
+    acris_master_rows: List[dict],
+    acris_legal_rows: List[dict],
+    acris_party_rows: List[dict],
+    rent_tag_row: Optional[dict] = None,
+    eviction_rows: Optional[List[dict]] = None,
+) -> Building:
+    b = Building(bbl=bbl)
+    if reg_row:
+        b.set_registration(as_registration(reg_row))
+    if rent_tag_row:
+        b.set_rent_stabilized(as_rent_tag(rent_tag_row))
+    for r in contact_rows:
+        b.add_contact(as_registration_contact(r))
+    for a in affordable_rows:
+        b.add_affordable(as_affordable(a))
+    for c in complaint_rows:
+        b.add_complaint(as_complaint(c))
+    for v in violation_rows:
+        b.add_violation(as_violation(v))
+    for m in acris_master_rows:
+        b.upsert_acris_master(as_acris_master(m))
+    for l in acris_legal_rows:
+        b.add_acris_legal(as_acris_legal(l))
+    for p in acris_party_rows:
+        b.add_acris_party(as_acris_party(p))
+    if eviction_rows:
+        for e in eviction_rows:
+            b.add_eviction(as_eviction(e))
+    return b

--- a/backend/common/models/complaint.py
+++ b/backend/common/models/complaint.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+from dataclasses import dataclass, field
+from typing import Optional, List, Dict
+from datetime import datetime
+from decimal import Decimal
+
+@dataclass
+class Complaint:
+    complaint_id: int
+    bbl: Optional[str]
+    borough: Optional[str]
+    block: Optional[int]
+    lot: Optional[int]
+    problem_id: Optional[int]
+    unit_type: Optional[str]
+    space_type: Optional[str]
+    type: Optional[str]
+    major_category: Optional[str]
+    minor_category: Optional[str]
+    complaint_status: Optional[str]
+    complaint_status_date: Optional[datetime]
+    problem_status: Optional[str]
+    problem_status_date: Optional[datetime]
+    status_description: Optional[str]
+    house_number: Optional[str]
+    street_name: Optional[str]
+    post_code: Optional[str]
+    apartment: Optional[str]

--- a/backend/common/models/eviction.py
+++ b/backend/common/models/eviction.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+from dataclasses import dataclass, field
+from typing import Optional, List, Dict
+from datetime import datetime
+from decimal import Decimal
+
+@dataclass
+class Eviction:
+    docket_number: Optional[str]
+    court_index_number: Optional[str]
+    bbl: Optional[str]
+    bin: Optional[int]
+    borough: Optional[str]
+    eviction_zip: Optional[str]
+    eviction_address: Optional[str]
+    eviction_apt_num: Optional[str]
+    community_board: Optional[int]
+    council_district: Optional[int]
+    census_tract: Optional[str]
+    nta: Optional[str]
+    latitude: Optional[float]
+    longitude: Optional[float]
+    executed_date: Optional[datetime]
+    residential_commercial_ind: Optional[str]
+    ejectment: Optional[str]
+    eviction_possession: Optional[str]
+    marshal_first_name: Optional[str]
+    marshal_last_name: Optional[str]

--- a/backend/common/models/registration.py
+++ b/backend/common/models/registration.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+from dataclasses import dataclass, field
+from typing import Optional, List, Dict
+from datetime import datetime
+from decimal import Decimal
+
+@dataclass
+class Registration:
+    bbl: str
+    bin: Optional[int] = None
+    boro_id: Optional[int] = None
+    boro: Optional[str] = None
+    block: Optional[int] = None
+    lot: Optional[int] = None
+    house_number: Optional[str] = None
+    street_name: Optional[str] = None
+    zip: Optional[str] = None
+    community_board: Optional[int] = None
+    last_registration_date: Optional[datetime] = None
+    registration_end_date: Optional[datetime] = None
+    registration_id: Optional[int] = None
+    building_id: Optional[int] = None

--- a/backend/common/models/registration_contact.py
+++ b/backend/common/models/registration_contact.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+from dataclasses import dataclass, field
+from typing import Optional, List, Dict
+from datetime import datetime
+from decimal import Decimal
+
+@dataclass
+class RegistrationContact:
+    registration_contact_id: int
+    registration_id: Optional[int]
+    type: Optional[str]
+    contact_description: Optional[str]
+    first_name: Optional[str]
+    last_name: Optional[str]
+    corporation_name: Optional[str]
+    business_house_number: Optional[str]
+    business_street_name: Optional[str]
+    business_city: Optional[str]
+    business_state: Optional[str]
+    business_zip: Optional[str]
+    business_apartment: Optional[str]

--- a/backend/common/models/rent_stabilized_tag.py
+++ b/backend/common/models/rent_stabilized_tag.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+from dataclasses import dataclass, field
+from typing import Optional, List, Dict
+
+@dataclass
+class RentStabilizedTag:
+    bbl: str
+    borough: Optional[str]
+    block: Optional[int]
+    lot: Optional[int]
+    zip: Optional[str]
+    city: Optional[str]
+    status: Optional[str]
+    source_year: Optional[int]

--- a/backend/common/models/violation.py
+++ b/backend/common/models/violation.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+from dataclasses import dataclass, field
+from typing import Optional, List, Dict
+from datetime import datetime
+from decimal import Decimal
+
+@dataclass
+class Violation:
+    violation_id: int
+    bbl: Optional[str]
+    bin: Optional[int]
+    block: Optional[int]
+    lot: Optional[int]
+    boro: Optional[str]
+    nov_description: Optional[str]
+    nov_type: Optional[str]
+    class_: Optional[str]
+    rent_impairing: Optional[bool]
+    violation_status: Optional[str]
+    current_status: Optional[str]
+    current_status_id: Optional[int]
+    current_status_date: Optional[datetime]
+    inspection_date: Optional[datetime]
+    nov_issued_date: Optional[datetime]
+    approved_date: Optional[datetime]
+    house_number: Optional[str]
+    street_name: Optional[str]
+    apartment: Optional[str]
+    story: Optional[str]

--- a/backend/infrastructures/postgres/building_repository.py
+++ b/backend/infrastructures/postgres/building_repository.py
@@ -1,0 +1,179 @@
+from typing import List, Dict, Any, Optional, Sequence
+from infrastructures.postgres.postgres_client import PostgresClient
+
+from common.models.building import (
+    build_building_from_rows,
+)
+
+class BuildingRepository:
+
+    def __init__(self):
+        self.client_factory = PostgresClient
+
+    def get_by_bbl(self, bbl: str):
+        with self.client_factory() as db:
+            reg_row = db.query_one(
+                """
+                SELECT
+                    bbl, bin, boro_id, boro, block, lot,
+                    house_number, street_name, zip, community_board,
+                    last_registration_date, registration_end_date,
+                    registration_id, building_id
+                FROM building_registrations
+                WHERE bbl = %s
+                """,
+                (bbl,),
+            )
+
+            contact_rows: List[Dict[str, Any]] = []
+            if reg_row and reg_row.get("registration_id") is not None:
+                contact_rows = db.query_all(
+                    """
+                    SELECT
+                        registration_contact_id, registration_id, type, contact_description,
+                        first_name, last_name, corporation_name,
+                        business_house_number, business_street_name,
+                        business_city, business_state, business_zip, business_apartment
+                    FROM building_registration_contacts
+                    WHERE registration_id = %s
+                    """,
+                    (reg_row["registration_id"],),
+                )
+
+            affordable_rows = db.query_all(
+                """
+                SELECT
+                    project_id,bbl,project_name,project_start_date,
+                    reporting_construction_type,extended_affordability_status,prevailing_wage_status,
+                    extremely_low_income_units,very_low_income_units,low_income_units,
+                    counted_rental_units,all_counted_units,total_units
+                FROM building_affordable_housing
+                WHERE bbl = %s
+                """,
+                (bbl,),
+            )
+
+            complaint_rows = db.query_all(
+                """
+                SELECT
+                    complaint_id, bbl, borough, block, lot, problem_id, unit_type, space_type,
+                    type, major_category, minor_category, complaint_status, complaint_status_date,
+                    problem_status, problem_status_date, status_description,
+                    house_number, street_name, post_code, apartment
+                FROM building_complaints
+                WHERE bbl = %s
+                """,
+                (bbl,),
+            )
+
+            violation_rows = db.query_all(
+                """
+                SELECT
+                    violation_id,bbl,bin,block,lot,boro,
+                    nov_description,nov_type,class,rent_impairing,
+                    violation_status,current_status,current_status_id,current_status_date,
+                    inspection_date,nov_issued_date,approved_date,
+                    house_number,street_name,apartment,story
+                FROM building_violations
+                WHERE bbl = %s
+                """,
+                (bbl,),
+            )
+
+            eviction_rows = db.query_all(
+                """
+                SELECT docket_number,
+                       court_index_number,
+                       bbl,
+                       bin,
+                       borough,
+                       eviction_zip,
+                       eviction_address,
+                       eviction_apt_num,
+                       community_board,
+                       council_district,
+                       census_tract,
+                       nta,
+                       latitude,
+                       longitude,
+                       executed_date,
+                       residential_commercial_ind,
+                       ejectment,
+                       eviction_possession,
+                       marshal_first_name,
+                       marshal_last_name
+                FROM building_evictions
+                WHERE bbl = %s
+                """,
+                (bbl,),
+            )
+
+            rent_tag_row = db.query_one(
+                """
+                SELECT
+                    bbl, borough, block, lot, zip, city, status, source_year
+                FROM building_rent_stabilized_list
+                WHERE bbl = %s
+                """,
+                (bbl,),
+            )
+
+            acris_legal_rows = db.query_all(
+                """
+                SELECT
+                    document_id, bbl, borough, block, lot
+                FROM building_acris_legals
+                WHERE bbl = %s
+                """,
+                (bbl,),
+            )
+            doc_ids = sorted({r["document_id"] for r in acris_legal_rows if r.get("document_id")})
+
+            acris_master_rows: List[Dict[str, Any]] = []
+            acris_party_rows: List[Dict[str, Any]] = []
+            if doc_ids:
+                placeholders = ", ".join(["%s"] * len(doc_ids))
+
+                acris_master_rows = db.query_all(
+                    f"""
+                    SELECT
+                        document_id, borough, doc_type, doc_date, doc_amount
+                    FROM building_acris_master
+                    WHERE document_id IN ({placeholders})
+                    """,
+                    tuple(doc_ids),
+                )
+
+                acris_party_rows = db.query_all(
+                    f"""
+                    SELECT
+                        document_id, party_type, name, address1, city, state, zip
+                    FROM building_acris_parties
+                    WHERE document_id IN ({placeholders})
+                    """,
+                    tuple(doc_ids),
+                )
+
+        building = build_building_from_rows(
+            bbl=bbl,
+            reg_row=reg_row,
+            contact_rows=contact_rows,
+            affordable_rows=affordable_rows,
+            complaint_rows=complaint_rows,
+            violation_rows=violation_rows,
+            acris_master_rows=acris_master_rows,
+            acris_legal_rows=acris_legal_rows,
+            acris_party_rows=acris_party_rows,
+            rent_tag_row=rent_tag_row,
+            eviction_rows=eviction_rows,
+        )
+        return building
+
+    def get_many_by_bbl(self, bbls: Sequence[str]) -> Dict[str, Any]:
+        result = {}
+        for bbl in bbls:
+            try:
+                result[bbl] = self.get_by_bbl(bbl)
+            except Exception as e:
+                print(f"[BuildingRepository] get_by_bbl failed for {bbl}: {e}")
+        return result

--- a/backend/tests/test_building_repository.py
+++ b/backend/tests/test_building_repository.py
@@ -1,0 +1,40 @@
+from dataclasses import asdict
+from decimal import Decimal
+from datetime import datetime
+import json
+
+from infrastructures.postgres.building_repository import BuildingRepository  # 경로는 프로젝트 구조에 맞게 조정
+
+def default_serializer(o):
+    if isinstance(o, datetime):
+        return o.isoformat()
+    if isinstance(o, Decimal):
+        return float(o)
+    return str(o)
+
+def main():
+    repo = BuildingRepository()
+    bbl = "1013510030"
+
+    building = repo.get_by_bbl(bbl)
+
+    print(f"BBL: {building.bbl}")
+    if building.registration:
+        print(f"Address: {building.registration.house_number} {building.registration.street_name}, ZIP={building.registration.zip}")
+    if building.rent_stabilized:
+        print(f"Rent-Stabilized: {building.rent_stabilized.status} (year={building.rent_stabilized.source_year})")
+
+    print(f"Contacts: {len(building.contacts)}")
+    print(f"Affordable records: {len(building.affordable)}")
+    print(f"Complaints: {len(building.complaints)}")
+    print(f"Violations: {len(building.violations)}")
+    print(f"Evictions: {len(building.evictions)}")
+    print(f"ACRIS docs: {len(building.acris_master)} "
+          f"(legals={sum(len(v) for v in building.acris_legals.values())}, "
+          f"parties={sum(len(v) for v in building.acris_parties.values())})")
+
+    print("\n=== Full JSON ===")
+    print(json.dumps(asdict(building), indent=2, default=default_serializer, ensure_ascii=False))
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
**User story**
As an administrator, I want core datasets (buildings, owners, evictions, violations, complaints, google reviews) to be ingested into our DB.

**Acceptance criteria**
- Building dataclasses defined (incl. Eviction) and aggregate Building supports evictions.
- BuildingRepository.get_by_bbl(bbl) returns a populated aggregate from DB using parameterized queries.
- Sources included in this PR: registrations, contacts, affordable housing, complaints, violations, rent-stabilized tag, ACRIS (legals/master/parties), evictions.
- Graceful handling when optional sections are missing (no errors, empty lists/None).
- Basic dedup rules applied (e.g., evictions by (docket_number, court_index_number)).
- Unit test covers a happy-path BBL and absence of sections.
