### PR TITLE
fix: switch axios baseURL to relative path for production compatibility

### DIFF
--- a/frontend/src/api/axiosInstance.ts
+++ b/frontend/src/api/axiosInstance.ts
@@ -1,7 +1,7 @@
 import axios from "axios";
 
 const axiosInstance = axios.create({
-  baseURL: "http://192.168.1.103:8000/api", // Use relative path for production compatibility
+  baseURL: "/api", // Use relative path for production compatibility
   timeout: 30000, // Increased timeout for large datasets
   headers: {
     "Content-Type": "application/json",


### PR DESCRIPTION
This pull request makes a small but important update to the API configuration to improve deployment compatibility.

* Changed the `baseURL` in `frontend/src/api/axiosInstance.ts` from a hardcoded IP address to a relative path (`/api`), making the frontend compatible with different production environments.