### PR TITLE
fix(admin): Display flagged reviews in moderation queue

### DIFF
--- a/backend/apps/community/models.py
+++ b/backend/apps/community/models.py
@@ -53,6 +53,7 @@ class CommunityReviews(models.Model):
     )  # NULL or 0<rating<=5.0
     title = models.TextField()
     body = models.TextField()
+    flagged = models.BooleanField(default=False)  # For admin moderation
     created_at = models.DateTimeField(auto_now_add=True)
     updated_at = models.DateTimeField(auto_now=True)
     deleted_at = models.DateTimeField(blank=True, null=True)

--- a/backend/apps/user/admin_views.py
+++ b/backend/apps/user/admin_views.py
@@ -175,19 +175,22 @@ def admin_flagged_reviews(request):
         # Also get flag counts from review_flags table if it exists
         result = []
         for review in reviews:
-            flag_count_result = _query_one(
-                """
-                SELECT COUNT(*) as count 
-                FROM review_flags 
-                WHERE review_id = %s
-                """,
-                (review["id"],),
-            )
-            flag_count = (
-                flag_count_result["count"]
-                if flag_count_result and flag_count_result.get("count") is not None
-                else 1
-            )
+            # Try to get flag count, but default to 1 if table doesn't exist
+            flag_count = 1
+            try:
+                flag_count_result = _query_one(
+                    """
+                    SELECT COUNT(*) as count 
+                    FROM review_flags 
+                    WHERE review_id = %s
+                    """,
+                    (review["id"],),
+                )
+                if flag_count_result and flag_count_result.get("count") is not None:
+                    flag_count = flag_count_result["count"]  # Preserve 0 as valid
+            except Exception:
+                # review_flags table might not exist, use default count
+                pass
 
             body_text = review["body"] or ""
             result.append(

--- a/backend/apps/user/tests.py
+++ b/backend/apps/user/tests.py
@@ -2586,3 +2586,35 @@ class AdminViewsAdditionalTests(TestCase):
         self.assertEqual(response.data[0]["reportedBy"], 1)
         # Author should be None when both email and username are None
         self.assertIsNone(response.data[0]["author"])
+
+    @patch("apps.user.admin_views._query_all")
+    @patch("apps.user.admin_views._query_one")
+    def test_admin_flagged_reviews_flag_count_query_error(
+        self, mock_query_one, mock_query_all
+    ):
+        """Test flagged reviews when review_flags table query fails"""
+        # Main query succeeds
+        mock_query_all.return_value = [
+            {
+                "id": 1,
+                "user_id": 1,
+                "bbl": "1234567890",
+                "title": "Test Review",
+                "body": "Test body",
+                "rating": 4.5,
+                "created_at": None,
+                "flagged": True,
+                "author_email": "test@example.com",
+                "author_username": "testuser",
+            }
+        ]
+        # Flag count query fails (e.g., review_flags table doesn't exist)
+        mock_query_one.side_effect = Exception("relation review_flags does not exist")
+
+        self.client.force_authenticate(user=self.admin_user)
+        response = self.client.get("/api/auth/admin/flagged-reviews/")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        # Should still return the review with default flag count of 1
+        self.assertEqual(len(response.data), 1)
+        self.assertEqual(response.data[0]["reportedBy"], 1)
+        self.assertEqual(response.data[0]["title"], "Test Review")


### PR DESCRIPTION
## Summary
Fixes an issue where flagged reviews were not being displayed in the Admin Dashboard moderation queue, even though the stats showed 2 flagged reviews.

## Changes
- **backend/apps/community/models.py**: Added `flagged` field to `CommunityReviews` model for documentation (field exists in DB but was missing from model)
- **backend/apps/user/admin_views.py**: Fixed `admin_flagged_reviews` to handle missing `review_flags` table gracefully with try/except
- **backend/apps/user/tests.py**: Added test `test_admin_flagged_reviews_flag_count_query_error` to maintain coverage

## Root Cause
The `admin_flagged_reviews` function was querying a `review_flags` table that doesn't exist. When this query failed, the entire function returned an empty list instead of the actual flagged reviews.

## Testing
- [x] Black formatting passes
- [x] Flake8 passes
- [x] New test added to maintain coverage